### PR TITLE
Include missing files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include *.md


### PR DESCRIPTION
Include missing files in sdist for #106

Tested with

```
++ mktemp -d
+ D=/tmp/tmp.LCvklhRnKX
+ trap 'rm -rf /tmp/tmp.LCvklhRnKX' EXIT
+ python -m venv /tmp/tmp.LCvklhRnKX
+ python setup.py sdist -d /tmp/tmp.LCvklhRnKX
running sdist
running egg_info
writing tvsort_sl.egg-info/PKG-INFO
writing dependency_links to tvsort_sl.egg-info/dependency_links.txt
writing top-level names to tvsort_sl.egg-info/top_level.txt
reading manifest file 'tvsort_sl.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'tvsort_sl.egg-info/SOURCES.txt'
warning: sdist: standard file not found: should have one of README, README.rst, README.txt, README.md

running check
creating tvsort_sl-1.1.12
creating tvsort_sl-1.1.12/tvsort_sl
creating tvsort_sl-1.1.12/tvsort_sl.egg-info
copying files to tvsort_sl-1.1.12...
copying MANIFEST.in -> tvsort_sl-1.1.12
copying contributing.md -> tvsort_sl-1.1.12
copying readme.md -> tvsort_sl-1.1.12
copying setup.py -> tvsort_sl-1.1.12
copying tvsort_sl/__init__.py -> tvsort_sl-1.1.12/tvsort_sl
copying tvsort_sl/app.py -> tvsort_sl-1.1.12/tvsort_sl
copying tvsort_sl/conf.py -> tvsort_sl-1.1.12/tvsort_sl
copying tvsort_sl/messages.py -> tvsort_sl-1.1.12/tvsort_sl
copying tvsort_sl/utils.py -> tvsort_sl-1.1.12/tvsort_sl
copying tvsort_sl.egg-info/PKG-INFO -> tvsort_sl-1.1.12/tvsort_sl.egg-info
copying tvsort_sl.egg-info/SOURCES.txt -> tvsort_sl-1.1.12/tvsort_sl.egg-info
copying tvsort_sl.egg-info/dependency_links.txt -> tvsort_sl-1.1.12/tvsort_sl.egg-info
copying tvsort_sl.egg-info/top_level.txt -> tvsort_sl-1.1.12/tvsort_sl.egg-info
Writing tvsort_sl-1.1.12/setup.cfg
Creating tar archive
removing 'tvsort_sl-1.1.12' (and everything under it)
+ cd /
+ /tmp/tmp.LCvklhRnKX/bin/pip install /tmp/tmp.LCvklhRnKX/tvsort_sl-1.1.12.tar.gz
Processing /tmp/tmp.LCvklhRnKX/tvsort_sl-1.1.12.tar.gz
Installing collected packages: tvsort-sl
  Running setup.py install for tvsort-sl: started
    Running setup.py install for tvsort-sl: finished with status 'done'
Successfully installed tvsort-sl-1.1.12
WARNING: You are using pip version 19.2.3, however version 20.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
+ echo Success
Success
++ rm -rf /tmp/tmp.LCvklhRnKX
```
